### PR TITLE
flake: Add initial flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "Hubble - A USB Recovery Tool for Exynos devices";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    in
+    {
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
+      packages = forAllSystems (system: {
+        default = self.packages.${system}.hubble;
+        hubble = nixpkgs.legacyPackages.${system}.callPackage (
+          {
+            lib,
+            stdenv,
+            python3,
+            python3Packages,
+            autoPatchelfHook,
+            writeShellScriptBin,
+            fetchPypi,
+            udev,
+          }:
+          let
+            pkg-about-override = python3Packages.pkg-about.overrideAttrs (prev: rec {
+              version = "1.3.1";
+              src = fetchPypi {
+                pname = "pkg_about";
+                inherit version;
+                hash = "sha256-EyD4GS/iU31ucsBvpBkcY9SgvBX1lYxQH8vvAcW4PCY=";
+              };
+            });
+            libusb = python3Packages.buildPythonPackage rec {
+              pname = "libusb";
+              version = "1.0.28";
+              pyproject = true;
+
+              src = fetchPypi {
+                inherit pname version;
+                hash = "sha256-8Ylppy6caIFiV7uhPvWD8kX+s9WS+8QuxYeWAegGUWc=";
+              };
+
+              dependencies = with python3Packages; [
+                pkg-about-override
+                setuptools
+                tox
+              ];
+
+              nativeBuildInputs = [
+                autoPatchelfHook
+              ];
+
+              buildInputs = [
+                udev
+              ];
+
+              buildSystem = with python3Packages; [
+                setuptools
+              ];
+            };
+          in
+          stdenv.mkDerivation {
+            name = "hubble";
+            installPhase = ''
+              install -Dm555 ${lib.getExe (
+                writeShellScriptBin "hubble" ''
+                  ${
+                    lib.getExe (
+                      python3.withPackages (
+                        pythonPkgs: with pythonPkgs; [
+                          coloredlogs
+                          libusb
+                          lz4
+                          pygments
+                          pyusb
+                        ]
+                      )
+                    )
+                  } ${./hubble.py} $@
+                ''
+              )} $out/bin/hubble
+            '';
+            dontUnpack = true;
+            meta.mainProgram = "hubble";
+          }
+        ) { };
+      });
+    };
+}


### PR DESCRIPTION
With this, we can run hubble on any distro that has Nix installed using the following command:

`nix run github:halal-beef/hubble -- -h`

(Or `nix run github:ungeskriptet/hubble/flake -- -h` while this PR is unmerged)