### PR TITLE
S5E9810: Correct S-BOOT Split Names

### DIFF
--- a/ExynosData/Exynos9810.json
+++ b/ExynosData/Exynos9810.json
@@ -7,7 +7,7 @@
             "length": 8192
         },
 
-        "epbl.bin": {
+        "bl31.bin": {
             "start": 8192,
             "length": 77824
         },


### PR DESCRIPTION
## Changes

  - Renamed `epbl.bin` to `bl31.bin`.

## Reason

For more Accurate Naming, EPBL became a Thing on S5E9820, So S5E9810 has BL31 instead.