### PR TITLE
Add Support for Exynos9610

### DIFF
--- a/ExynosData/Exynos9610.json
+++ b/ExynosData/Exynos9610.json
@@ -1,0 +1,35 @@
+{
+    "response_support": true,
+    "files_to_send": [],
+    "bootloader_splits": {
+        "fwbl1.bin": {
+            "start": 0,
+            "length": 8192
+        },
+
+        "epbl.bin": {
+            "start": 8192,
+            "length": 77824
+        },
+
+        "bl2.bin": {
+            "start": 86016,
+            "length": 192512
+        },
+
+        "repeat-fwbl1.bin": {
+            "start": 0,
+            "length": 8192
+        },
+
+        "u-boot.bin": {
+            "start": 368640,
+            "length": 1572864
+        },
+
+        "el3_mon.bin": {
+            "start": 1941504,
+            "length": 262144
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ https://github.com/user-attachments/assets/78ca9dda-04c2-45d3-ad47-5a713086e33e
 |:----------|:-----------|:---------------:|:----------------------------------------|:-----:|
 | Galaxy S9 | starlte    | `G960FXXUHFVG4` | [Robotix](https://github.com/Robotix22) | ✅    |
 
+### Exynos 9610 Devices
+
+| Name       | Codename   | Tested Firmware | Tested by                                   | State |
+|:-----------|:-----------|:---------------:|:--------------------------------------------|:-----:|
+| Galaxy A51 | a51        | `A515FXXU8HWK1` | [AlexFurina](https://github.com/AlexFurina) |✅     |
+
 ### Exynos 7580 Devices
 
 | Name             | Codename   | Tested Firmware | Tested by                                       | State |


### PR DESCRIPTION
Changes:

Added Exynos9610 Details to ExynosData/Exynos9610.json
Updated README.md to Add info about the tested Device

Reason:

i had sboot splits for this device since ages and when i saw this repo i had the idea to add support for it here.
